### PR TITLE
Update jenkinstracking.rb

### DIFF
--- a/lib/puppet/reports/jenkinstracking.rb
+++ b/lib/puppet/reports/jenkinstracking.rb
@@ -37,7 +37,7 @@ Submits the execution record to Jenkins for its deployment notification plugin.
 
   def process
     #we only care about sending reports that contain the track resource
-    if self.resource_statuses.include?("Track")
+    if self.resource_statuses.any? { |resource| /^\[\"Track\[/ =~ resource.to_s }
       send_report(self.to_yaml)
     end
   end


### PR DESCRIPTION
I am suggesting an update to the section that filters on reports that include the 'track' resource. The original code was treating the key as 'Track', but the key in the report is actually 'Track[filename]'. I replaced the statement with an enumerable and converted the object to a string so that I could use a regex expression against it. I have tested this and it appears to be working.
